### PR TITLE
Implement UDP-streaming telemetry logger plugin + hooks into logging module

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -232,6 +232,8 @@ AC_ARG_ENABLE([all-loggers],
               [
                AS_IF([test "x$enable_json_logger" != "xyes"],
                      [enable_json_logger=no])
+               AS_IF([test "x$enable_telem_logger" != "xyes"],
+                     [enable_telem_logger=no])
               ],
               [])
 
@@ -336,6 +338,12 @@ AC_ARG_ENABLE([json-logger],
               [AS_IF([test "x$enable_json_logger" != "xyes"],
                      [enable_json_logger=no])],
               [enable_json_logger=no])
+AC_ARG_ENABLE([telem-logger],
+              [AS_HELP_STRING([--enable-telem-logger],
+                              [Enable external telemetry logger ])],
+              [AS_IF([test "x$enable_telem_logger" != "xyes"],
+                     [enable_telem_logger=no])],
+              [enable_telem_logger=no])
 
 AC_ARG_ENABLE([systemd-sockets],
               [AS_HELP_STRING([--enable-systemd-sockets],
@@ -650,6 +658,7 @@ AM_CONDITIONAL([ENABLE_NANOMSGEVH], [test "x$enable_nanomsg_event_handler" = "xy
 AM_CONDITIONAL([ENABLE_GELFEVH], [test "x$enable_gelf_event_handler" = "xyes"])
 
 AM_CONDITIONAL([ENABLE_JSONLOGGER], [test "x$enable_json_logger" = "xyes"])
+AM_CONDITIONAL([ENABLE_TELEMLOGGER], [test "x$enable_telem_logger" = "xyes"])
 
 AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
                #include <stdlib.h>
@@ -1086,6 +1095,9 @@ echo "External loggers:"
 AM_COND_IF([ENABLE_JSONLOGGER],
 	[echo "    JSON file logger:      yes"],
 	[echo "    JSON file logger:      no"])
+AM_COND_IF([ENABLE_TELEMLOGGER],
+	[echo "    Telem logger:      yes"],
+	[echo "    Telem logger:      no"])
 AM_COND_IF([ENABLE_JAVASCRIPT_MODULES], [
 	echo "JavaScript modules:        yes"
 	echo "    Using npm:             $NPM"

--- a/janus-local.Dockerfile
+++ b/janus-local.Dockerfile
@@ -55,6 +55,7 @@ RUN ./configure \
     --disable-rabbitmq \
     --disable-mqtt \
     --disable-all-plugins \
+    --disable-all-loggers \
     --enable-plugin-videoroom \
     --enable-telem-logger \
     --enable-static

--- a/janus-local.Dockerfile
+++ b/janus-local.Dockerfile
@@ -2,7 +2,7 @@
 # Platforms: Has been tested on Mac ARM and Linux x86 + ARM.
 #
 # Build with: docker build --no-cache -t janus -f janus.Dockerfile .
-# Run with: `docker run -p 0.0.0.0:8188:8188 -p 8088:8088 janus` for basic API testing
+# Run with: `docker run -p 0.0.0.0:8188:8188 -p 8088:8088 -p 9090:9090 janus` for basic API testing
 # Run with: `docker run -d --network host janus` on Linux to expose all UDP ports for WebRTC
 FROM public.ecr.aws/docker/library/alpine:3.17.0 as base
 
@@ -77,6 +77,8 @@ COPY janus.jcfg /usr/local/etc/janus/janus.jcfg
 # Expose port explicitly for use by Testcontainers
 EXPOSE 8188
 EXPOSE 8088
+# Expose port for UDP telemetry
+EXPOSE 9090
 
 # Run the server
 # ENTRYPOINT ["/usr/local/bin/janus"]

--- a/janus-local.Dockerfile
+++ b/janus-local.Dockerfile
@@ -56,6 +56,7 @@ RUN ./configure \
     --disable-mqtt \
     --disable-all-plugins \
     --enable-plugin-videoroom \
+    --enable-telem-logger \
     --enable-static
 RUN make && make install && make configs
 

--- a/janus-local.Dockerfile
+++ b/janus-local.Dockerfile
@@ -73,6 +73,8 @@ RUN echo "general: {}" > /usr/local/etc/janus/janus.plugin.videoroom.jcfg
 
 # Setup the broader janus config
 COPY janus.jcfg /usr/local/etc/janus/janus.jcfg
+# Setup the telemetry log stream
+COPY janus.plugin.telem_logger.jcfg /usr/local/etc/janus/janus.plugin.telem_logger.jcfg
 
 # Expose port explicitly for use by Testcontainers
 EXPOSE 8188

--- a/janus.plugin.telem_logger.jcfg
+++ b/janus.plugin.telem_logger.jcfg
@@ -1,0 +1,4 @@
+general: {
+	udp_address = "127.0.0.1",
+	udp_port = 9099,
+}

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -375,6 +375,14 @@ conf_DATA += ../conf/janus.logger.jsonlog.jcfg.sample
 EXTRA_DIST += ../conf/janus.logger.jsonlog.jcfg.sample
 endif
 
+if ENABLE_TELEMLOGGER
+logger_LTLIBRARIES += loggers/libjanus_telem.la
+loggers_libjanus_telem_la_SOURCES = loggers/janus_telem.c
+loggers_libjanus_telem_la_CFLAGS = $(loggers_cflags)
+loggers_libjanus_telem_la_LDFLAGS = $(loggers_ldflags)
+loggers_libjanus_telem_la_LIBADD = $(loggers_libadd)
+endif
+
 ##
 # Plugins
 ##

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -4,7 +4,7 @@ CLEANFILES = $(NULL)
 bin_PROGRAMS = janus
 
 headerdir = $(includedir)/janus
-header_HEADERS = apierror.h config.h log.h debug.h mutex.h record.h \
+header_HEADERS = apierror.h config.h log.h debug.h mutex.h telem.h record.h \
 	rtcp.h rtp.h rtpsrtp.h sdp-utils.h ip-utils.h utils.h refcount.h text2pcap.h
 
 pluginsheaderdir = $(includedir)/janus/plugins
@@ -114,6 +114,7 @@ janus_SOURCES = \
 	version.h \
 	text2pcap.c \
 	text2pcap.h \
+	telem.h \
 	plugins/plugin.c \
 	plugins/plugin.h \
 	transports/transport.h \

--- a/src/ice.c
+++ b/src/ice.c
@@ -39,6 +39,19 @@
 #include "ip-utils.h"
 #include "events.h"
 
+/* Special logger macro that directly sends specifically-formatted lines to
+	Janus' logging system. These telemetered logs are always logged, regardless
+	of the configured runtime log level of the Janus core.
+ */
+#define JANUS_TELEMETER_LOG(format, ...) \
+do { \
+	char janus_log_ts[64] = ""; \
+	snprintf(janus_log_ts, sizeof(janus_log_ts), "TELEM [%ld] ", janus_get_real_time()); \
+	JANUS_PRINT("%s" format, \
+		janus_log_ts, \
+		##__VA_ARGS__); \
+} while (0)
+
 /* STUN server/port, if any */
 static char *janus_stun_server = NULL;
 static uint16_t janus_stun_port = 0;
@@ -2678,7 +2691,7 @@ static void janus_ice_cb_nice_recv(NiceAgent *agent, guint stream_id, guint comp
 				}
 
 				guint16 in_seqnum = ntohs(header->seq_number);
-				JANUS_LOG(LOG_NACK, "[%"SCNu64"] [RECEIVER] Packet %"SCNu16" arrived\n", handle->handle_id, in_seqnum);
+				JANUS_TELEMETER_LOG("%"SCNu64" received %"SCNu16"\n", handle->handle_id, in_seqnum);
 
 				if(rtx) {
 					/* The original sequence number is in the first two bytes of the payload */
@@ -5284,3 +5297,4 @@ void janus_ice_dtls_handshake_done(janus_ice_handle *handle) {
 			session->session_id, handle->handle_id, handle->opaque_id, info);
 	}
 }
+

--- a/src/ice.c
+++ b/src/ice.c
@@ -3328,11 +3328,13 @@ telemeter_packet:
 void janus_telemeter_recv_rtp_packet(janus_ice_recv_rtp_packet_telem *pkt_telem) {
 	if (pkt_telem) {
 		JANUS_TELEMETER_LOG(\
-			"{\"event\":\"pkt\",\"session\":%lu,\"handle\": %lu,\"seqnum\": %u,\"size\": %lu,\"rtx\": %u,\"dup\": %d,\"nacks\": %d,\"keyframe\": %d}",
-			pkt_telem->session, pkt_telem->handle,
-			pkt_telem->rtp_seqnum, pkt_telem->rtp_size,
-			pkt_telem->is_rtx_pkt, pkt_telem->is_duplicate,
-			pkt_telem->nack_count, pkt_telem->is_keyframe
+			"{\"event\":\"pkt\",\"session\":%lu,\"handle\": %lu,\"seqnum\": %u,\"size\": %lu,\"rtx\": %s,\"dup\": %s,\"nacks\": %d,\"keyframe\": %s}",
+			pkt_telem->session, pkt_telem->handle, pkt_telem->rtp_seqnum,
+			pkt_telem->rtp_size,
+			pkt_telem->is_rtx_pkt == 1 ? "true" : "false",
+			pkt_telem->is_duplicate == 1 ? "true" : "false",
+			pkt_telem->nack_count,
+			pkt_telem->is_keyframe == 1 ? "true" : "false"
 		);
 	}
 }

--- a/src/ice.c
+++ b/src/ice.c
@@ -38,19 +38,7 @@
 #include "apierror.h"
 #include "ip-utils.h"
 #include "events.h"
-
-/* Special logger macro that directly sends specifically-formatted lines to
-	Janus' logging system. These telemetered logs are always logged, regardless
-	of the configured runtime log level of the Janus core.
- */
-#define JANUS_TELEMETER_LOG(format, ...) \
-do { \
-	char janus_log_ts[64] = ""; \
-	snprintf(janus_log_ts, sizeof(janus_log_ts), "%s", TELEM_LOG_PREFIX); \
-	JANUS_PRINT("%s" format, \
-		janus_log_ts, \
-		##__VA_ARGS__); \
-} while (0)
+#include "telem.h"
 
 #define TELEMETER_GENERAL_PACKET(session, handle, seqnum, is_rtx, is_duplicate, nack_cnt, is_keyframe) \
 	JANUS_TELEMETER_LOG(\

--- a/src/ice.c
+++ b/src/ice.c
@@ -40,27 +40,12 @@
 #include "events.h"
 #include "telem.h"
 
-#define TELEMETER_GENERAL_PACKET(session, handle, seqnum, is_rtx, is_duplicate, nack_cnt, is_keyframe) \
-	JANUS_TELEMETER_LOG(\
-		"{\
-			\"event\":\"pkt\",\
-			\"session\":%lu,\
-			\"handle\": %lu,\
-			\"seqnum\": %u,\
-			\"rtx\": %u,\
-			\"dup\": %d,\
-			\"nacks\": %d,\
-			\"keyframe\": %d\
-		}",\
-		(uint64_t)(session), (uint64_t)(handle), (uint16_t)(seqnum),\
-		(uint32_t)(is_rtx),\
-		(int8_t)(is_duplicate), (int8_t)(nack_cnt), (int32_t)(is_keyframe),\
-	)
 
 typedef struct janus_ice_recv_rtp_packet_telem {
 	uint64_t session;
 	uint64_t handle;
 	uint16_t rtp_seqnum;
+	uint64_t rtp_size;
 	uint8_t is_rtx_pkt;
 	int8_t is_duplicate;  // -1: unknown
 	int8_t nack_count; // -1: unknown
@@ -2711,6 +2696,7 @@ static void janus_ice_cb_nice_recv(NiceAgent *agent, guint stream_id, guint comp
 				packet_telem.session = session->session_id;
 				packet_telem.handle = handle->handle_id;
 				packet_telem.rtp_seqnum = ntohs(header->seq_number);
+				packet_telem.rtp_size = buflen;
 				packet_telem.is_rtx_pkt = rtx;
 				packet_telem.is_keyframe = -1;
 				packet_telem.nack_count = -1;
@@ -3342,11 +3328,11 @@ telemeter_packet:
 void janus_telemeter_recv_rtp_packet(janus_ice_recv_rtp_packet_telem *pkt_telem) {
 	if (pkt_telem) {
 		JANUS_TELEMETER_LOG(\
-			"{\"event\":\"pkt\",\"session\":%lu,\"handle\": %lu,\"seqnum\": %u,\"rtx\": %u,\"dup\": %d,\"nacks\": %d,\"keyframe\": %d}",
+			"{\"event\":\"pkt\",\"session\":%lu,\"handle\": %lu,\"seqnum\": %u,\"size\": %lu,\"rtx\": %u,\"dup\": %d,\"nacks\": %d,\"keyframe\": %d}",
 			pkt_telem->session, pkt_telem->handle,
-			pkt_telem->rtp_seqnum, pkt_telem->is_rtx_pkt,
-			pkt_telem->is_duplicate, pkt_telem->nack_count,
-			pkt_telem->is_keyframe
+			pkt_telem->rtp_seqnum, pkt_telem->rtp_size,
+			pkt_telem->is_rtx_pkt, pkt_telem->is_duplicate,
+			pkt_telem->nack_count, pkt_telem->is_keyframe
 		);
 	}
 }

--- a/src/log.c
+++ b/src/log.c
@@ -17,6 +17,7 @@
 #include <unistd.h>
 
 #include "log.h"
+#include "telem.h"
 #include "utils.h"
 #include "loggers/logger.h"
 

--- a/src/loggers/janus_telem.c
+++ b/src/loggers/janus_telem.c
@@ -231,7 +231,7 @@ static void janus_threadedlogger_incoming_logline(int64_t timestamp, const char 
 
 // Helper macro to pack a payload; allocates heap memory via glib that must be freed
 #define PACK_TELEMETRY_MSG(seqnum, timestamp, msg) \
-	g_strdup_printf("{\"seqnum\":%lu,\"time\":%lu,\"msg\":\"%s\"}", \
+	g_strdup_printf("{\"seqnum\":%lu,\"time\":%lu,\"msg\":{%s}", \
         (uint64_t)seqnum, (uint64_t)timestamp, (char*)msg)
 
 /* Worker thread function - reads queued log messages and writes them on the UDP socket */

--- a/src/loggers/janus_telem.c
+++ b/src/loggers/janus_telem.c
@@ -14,8 +14,8 @@
 /* Plugin information */
 #define JANUS_THREADED_LOGGER_VERSION		    1
 #define JANUS_THREADED_LOGGER_VERSION_STRING	"0.0.1"
-#define JANUS_THREADED_LOGGER_DESCRIPTION	    "This plugin pushes telemetry data to a Parallel Systems Telemetry client over UDP."
-#define JANUS_THREADED_LOGGER_NAME		        "JANUS Telemetry plugin"
+#define JANUS_THREADED_LOGGER_DESCRIPTION	    "This plugin pushes streams of telemetry data to a Parallel Systems Telemetry client over UDP."
+#define JANUS_THREADED_LOGGER_NAME		        "JANUS Telemetry streaming plugin"
 #define JANUS_THREADED_LOGGER_AUTHOR		    "Parallel Systems"
 #define JANUS_THREADED_LOGGER_PACKAGE		    TELEM_PLUGIN_PACKAGE_NAME
 
@@ -89,10 +89,10 @@ janus_logger *create(void) {
 /* Initialize the plugin */
 static int janus_threadedlogger_init(const char *server_name, const char *config_path) {
     if(g_atomic_int_get(&initialized) || g_atomic_int_get(&stopping)) {
-        JANUS_LOG(LOG_ERR, "Threaded logger already initialized\n");
+        JANUS_LOG(LOG_ERR, "Telemetry logger already initialized\n");
         return -1;
     }
-    JANUS_LOG(LOG_INFO, "Initializing threaded logger plugin\n");
+    JANUS_LOG(LOG_INFO, "Initializing telemetry logger plugin\n");
 
     /* Initialize async queue for log entries */
     log_queue = g_async_queue_new_full((GDestroyNotify)free_log_entry);
@@ -136,7 +136,7 @@ static int janus_threadedlogger_init(const char *server_name, const char *config
 		return -1;
 	}
 
-    JANUS_LOG(LOG_INFO, "Threaded logger plugin initialized (filter: '%s')\n", TELEM_LOG_PREFIX);
+    JANUS_LOG(LOG_INFO, "Telemetry logger plugin initialized (filter: '%s')\n", TELEM_LOG_PREFIX);
     return 0;
 }
 
@@ -254,7 +254,7 @@ static void *worker_thread_func(void *arg) {
                 }
                 g_free(telemetered_msg);
             } else {
-                JANUS_LOG(LOG_WARN, "Failed to allocate telemetry messgage\n");
+                JANUS_LOG(LOG_WARN, "Failed to allocate telemetry message\n");
             }
         }
     }

--- a/src/loggers/janus_telem.c
+++ b/src/loggers/janus_telem.c
@@ -9,7 +9,7 @@
 #include <sys/socket.h>
 
 #include "logger.h"
-#include "../debug.h"
+#include "../telem.h"
 
 /* Plugin information */
 #define JANUS_THREADED_LOGGER_VERSION		    1

--- a/src/loggers/janus_telem.c
+++ b/src/loggers/janus_telem.c
@@ -89,7 +89,7 @@ janus_logger *create(void) {
 
 /* Initialize the plugin */
 static int janus_threadedlogger_init(const char *server_name, const char *config_path) {
-    if(g_atomic_int_get(&initialized) || !g_atomic_int_get(&stopping)) {
+    if(g_atomic_int_get(&initialized) || g_atomic_int_get(&stopping)) {
         JANUS_LOG(LOG_ERR, "Threaded logger already initialized\n");
         return -1;
     }
@@ -246,10 +246,10 @@ static void *worker_thread_func(void *arg) {
             gssize ret = g_socket_send_to(log_socket, log_address, telemetered_msg, strlen(telemetered_msg), NULL, &error);
             if(ret < 0) {
                 if(error) {
-                    JANUS_LOG(LOG_WARN, "Failed to send UDP log message (%llu): %s\n", ret, error->message);
+                    JANUS_LOG(LOG_WARN, "Failed to send UDP log message (%lld): %s\n", ret, error->message);
                     g_error_free(error);
                 } else {
-                    JANUS_LOG(LOG_WARN, "Failed to send UDP log message (%llu)\n", ret);
+                    JANUS_LOG(LOG_WARN, "Failed to send UDP log message (%lld)\n", ret);
                 }
             }
             

--- a/src/loggers/logger.h
+++ b/src/loggers/logger.h
@@ -82,6 +82,9 @@ janus_logger *create(void) {
 
 #include "../utils.h"
 
+/* Prefix for telemetry log filtering */
+#define TELEM_LOG_PREFIX  "TELEM"
+#define TELEM_PLUGIN_PACKAGE_NAME "janus.plugin.threadedlogger"
 
 /*! \brief Version of the API, to match the one logger plugins were compiled against */
 #define JANUS_LOGGER_API_VERSION	3

--- a/src/loggers/logger.h
+++ b/src/loggers/logger.h
@@ -82,10 +82,6 @@ janus_logger *create(void) {
 
 #include "../utils.h"
 
-/* Prefix for telemetry log filtering */
-#define TELEM_LOG_PREFIX  "TELEM"
-#define TELEM_PLUGIN_PACKAGE_NAME "janus.plugin.threadedlogger"
-
 /*! \brief Version of the API, to match the one logger plugins were compiled against */
 #define JANUS_LOGGER_API_VERSION	3
 

--- a/src/plugins/janus_videoroom.c
+++ b/src/plugins/janus_videoroom.c
@@ -13385,3 +13385,16 @@ static void *janus_videoroom_remote_publisher_thread(void *user_data) {
 	g_thread_unref(g_thread_self());
 	return NULL;
 }
+
+/* Special logger macro that directly sends specifically-formatted lines to
+	Janus' logging system. These telemetered logs are always logged, regardless
+	of the configured runtime log level of the Janus core.
+ */
+#define JANUS_VIDEOROOM_TELEMETER_LOG(format, ...) \
+do { \
+	char janus_log_ts[64] = ""; \
+	snprintf(janus_log_ts, sizeof(janus_log_ts), "[%ld]", janus_get_real_time()); \
+	JANUS_PRINT("%s" format, \
+		janus_log_ts, \
+		##__VA_ARGS__); \
+} while (0)

--- a/src/plugins/janus_videoroom.c
+++ b/src/plugins/janus_videoroom.c
@@ -13385,16 +13385,3 @@ static void *janus_videoroom_remote_publisher_thread(void *user_data) {
 	g_thread_unref(g_thread_self());
 	return NULL;
 }
-
-/* Special logger macro that directly sends specifically-formatted lines to
-	Janus' logging system. These telemetered logs are always logged, regardless
-	of the configured runtime log level of the Janus core.
- */
-#define JANUS_VIDEOROOM_TELEMETER_LOG(format, ...) \
-do { \
-	char janus_log_ts[64] = ""; \
-	snprintf(janus_log_ts, sizeof(janus_log_ts), "[%ld]", janus_get_real_time()); \
-	JANUS_PRINT("%s" format, \
-		janus_log_ts, \
-		##__VA_ARGS__); \
-} while (0)

--- a/src/telem.h
+++ b/src/telem.h
@@ -1,0 +1,23 @@
+#ifndef JANUS_TELEM_H
+#define JANUS_TELEM_H
+
+#include "debug.h"
+
+/* Prefix for telemetry log filtering */
+#define TELEM_LOG_PREFIX  "TELEM"
+#define TELEM_PLUGIN_PACKAGE_NAME "janus.plugin.threadedlogger"
+
+/* Special logger macro that directly sends specifically-formatted lines to
+	Janus' logging system. These telemetered logs are always logged, regardless
+	of the configured runtime log level of the Janus core.
+ */
+#define JANUS_TELEMETER_LOG(format, ...) \
+do { \
+	char telem_prefix[16] = ""; \
+	snprintf(telem_prefix, sizeof(telem_prefix), "%s", TELEM_LOG_PREFIX); \
+	JANUS_PRINT("%s" format, \
+		telem_prefix, \
+		##__VA_ARGS__); \
+} while (0)
+
+#endif

--- a/src/telem.h
+++ b/src/telem.h
@@ -5,7 +5,7 @@
 
 /* Prefix for telemetry log filtering */
 #define TELEM_LOG_PREFIX  "TELEM"
-#define TELEM_PLUGIN_PACKAGE_NAME "janus.plugin.threadedlogger"
+#define TELEM_PLUGIN_PACKAGE_NAME "janus.plugin.telem_logger"
 
 /* Special logger macro that directly sends specifically-formatted lines to
 	Janus' logging system. These telemetered logs are always logged, regardless


### PR DESCRIPTION
# Background
Janus has a logging system that is inadequate for our visibility needs. We want to connect it to our telemetry service, which offers this functionality.

# Description
Bootstraps a makeshift telemetry module on top of the existing logging infrastructure, using a combination of macros and message prefixes.

Any part of Janus' Core or Plugins can use the `JANUS_TELEMETER_LOG` macro to send a specially-formatted message through the logging system to the new `telem-logger` module.

`--enable-telem-logger` must be passed in as a configuration flag to enable this.

This must be used in conjunction with the `janus-telem-proxy` in monorail to connect the data streamed from the `telem-logger` plugin to the actual telemetry service.
