### PR TITLE
Fix memory leak in telemetry logger

### DIFF
--- a/src/loggers/janus_telem.c
+++ b/src/loggers/janus_telem.c
@@ -345,12 +345,14 @@ static void *worker_thread_func(void *arg) {
                 JANUS_LOG(LOG_WARN, "Failed to allocate telemetry message\n");
             }
         }
+        // We can free this entry now that it's popped off the queue
+        free_log_entry(entry);
     }
 
     JANUS_LOG(LOG_INFO, "Worker thread stopped\n");
     return NULL;
 }
-/* Free log entry - async destructor function for each queue entry when it's popped off */
+/* Free log entry - async destructor function for each remaining queue entry when the queue itself is unref'd */
 static void free_log_entry(log_entry_t *entry) {
     if(entry) {
         if (entry->message)


### PR DESCRIPTION
# Description
There was an observed memory leak in the Janus runtime. Valgrind showed that the telem logger was the primary cause of the leaking:
```
==48== HEAP SUMMARY:
==48==     in use at exit: 3,792,804 bytes in 41,570 blocks
==48==   total heap usage: 291,980 allocs, 250,410 frees, 43,667,518 bytes allocated
==48== 
==48== 24 bytes in 1 blocks are definitely lost in loss record 265 of 777
==48==    at 0x48D9350: malloc (in /usr/libexec/valgrind/vgpreload_memcheck-arm64-linux.so)
==48==    by 0x5098A73: g_malloc (in /usr/lib/libglib-2.0.so.0.7400.7)
==48==    by 0x508FBAB: g_list_append (in /usr/lib/libglib-2.0.so.0.7400.7)
==48==    by 0x1281C7: janus_config_get_categories (config.c:507)
==48==    by 0x5E77857: janus_videoroom_init (janus_videoroom.c:3593)
==48==    by 0x11EC9F: main (janus.c:5642)
==48== 
==48== 256 (96 direct, 160 indirect) bytes in 1 blocks are definitely lost in loss record 749 of 777
==48==    at 0x48D9350: malloc (in /usr/libexec/valgrind/vgpreload_memcheck-arm64-linux.so)
==48==    by 0x5098A73: g_malloc (in /usr/lib/libglib-2.0.so.0.7400.7)
==48==    by 0x50838A3: g_hash_table_new_full (in /usr/lib/libglib-2.0.so.0.7400.7)
==48==    by 0x14A577: janus_ice_cb_nice_recv (ice.c:3052)
==48==    by 0x493E99B: ??? (in /usr/lib/libnice.so.10.12.0)
==48==    by 0x493AC33: ??? (in /usr/lib/libnice.so.10.12.0)
==48==    by 0x4EA38DB: ??? (in /usr/lib/libgio-2.0.so.0.7400.7)
==48==    by 0x5093DC7: g_main_context_dispatch (in /usr/lib/libglib-2.0.so.0.7400.7)
==48==    by 0x509400F: ??? (in /usr/lib/libglib-2.0.so.0.7400.7)
==48==    by 0x5094437: g_main_loop_run (in /usr/lib/libglib-2.0.so.0.7400.7)
==48==    by 0x142397: janus_ice_handle_thread (ice.c:1335)
==48==    by 0x50B588B: ??? (in /usr/lib/libglib-2.0.so.0.7400.7)
==48== 
==48== 6,776 (40 direct, 6,736 indirect) bytes in 1 blocks are definitely lost in loss record 774 of 777
==48==    at 0x48D9350: malloc (in /usr/libexec/valgrind/vgpreload_memcheck-arm64-linux.so)
==48==    by 0x4BF54BB: CRYPTO_zalloc (in /lib/libcrypto.so.3)
==48==    by 0x4BD8C9F: EVP_RAND_CTX_new (in /lib/libcrypto.so.3)
==48==    by 0x4C2695B: ??? (in /lib/libcrypto.so.3)
==48==    by 0x4C276BB: RAND_get0_public (in /lib/libcrypto.so.3)
==48==    by 0x4C2779B: RAND_bytes_ex (in /lib/libcrypto.so.3)
==48==    by 0x1885DB: janus_random_uint64_full (utils.c:85)
==48==    by 0x18863F: janus_random_uint64 (utils.c:93)
==48==    by 0x5E86D5B: janus_videoroom_process_synchronous_request (janus_videoroom.c:4751)
==48==    by 0x5E9B9B3: janus_videoroom_handle_message (janus_videoroom.c:8109)
==48==    by 0x158923: janus_process_incoming_request (janus.c:1753)
==48==    by 0x15F037: janus_transport_task (janus.c:3474)
==48== 
==48== 3,694,544 (488,304 direct, 3,206,240 indirect) bytes in 20,346 blocks are definitely lost in loss record 777 of 777
==48==    at 0x48D9350: malloc (in /usr/libexec/valgrind/vgpreload_memcheck-arm64-linux.so)
==48==    by 0x5098A73: g_malloc (in /usr/lib/libglib-2.0.so.0.7400.7)
==48==    by 0x5DDBF23: janus_telemlogger_incoming_logline (janus_telem.c:300)
==48==    by 0x5DDBF23: janus_telemlogger_incoming_logline (janus_telem.c:288)
==48==    by 0x16353F: janus_log_thread (log.c:128)
==48==    by 0x50B588B: ??? (in /usr/lib/libglib-2.0.so.0.7400.7)
==48==    by 0x405E99F: ??? (in /lib/ld-musl-aarch64.so.1)
==48== 
==48== LEAK SUMMARY:
==48==    definitely lost: 488,464 bytes in 20,349 blocks
==48==    indirectly lost: 3,213,136 bytes in 20,393 blocks
==48==      possibly lost: 0 bytes in 0 blocks
==48==    still reachable: 79,828 bytes in 733 blocks
==48==         suppressed: 0 bytes in 0 blocks
==48== Reachable blocks (those to which a pointer was found) are not shown.
==48== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==48== 
==48== For lists of detected and suppressed errors, rerun with: -s
==48== ERROR SUMMARY: 4 errors from 4 contexts (suppressed: 0 from 0)
```

This was a simple oversight; `g_async_queue_new_full()`'s destructor callback ensures memory is free'd from queue entries when the queue itself is dereferenced, not when individual elements are popped off. This PR simply runs that cleanup function on each entry as it's popped off the queue.

# Verification
Running valgrind:
```
==17== 
==17== HEAP SUMMARY:
==17==     in use at exit: 97,464 bytes in 868 blocks
==17==   total heap usage: 63,217 allocs, 62,349 frees, 23,623,277 bytes allocated
==17== 
==17== 24 bytes in 1 blocks are definitely lost in loss record 268 of 765
==17==    at 0x48D9350: malloc (in /usr/libexec/valgrind/vgpreload_memcheck-arm64-linux.so)
==17==    by 0x5098A73: g_malloc (in /usr/lib/libglib-2.0.so.0.7400.7)
==17==    by 0x508FBAB: g_list_append (in /usr/lib/libglib-2.0.so.0.7400.7)
==17==    by 0x1281C7: janus_config_get_categories (config.c:507)
==17==    by 0x5E77857: janus_videoroom_init (janus_videoroom.c:3593)
==17==    by 0x11EC9F: main (janus.c:5642)
==17== 
==17== 6,776 (40 direct, 6,736 indirect) bytes in 1 blocks are definitely lost in loss record 764 of 765
==17==    at 0x48D9350: malloc (in /usr/libexec/valgrind/vgpreload_memcheck-arm64-linux.so)
==17==    by 0x4BF54BB: CRYPTO_zalloc (in /lib/libcrypto.so.3)
==17==    by 0x4BD8C9F: EVP_RAND_CTX_new (in /lib/libcrypto.so.3)
==17==    by 0x4C2695B: ??? (in /lib/libcrypto.so.3)
==17==    by 0x4C276BB: RAND_get0_public (in /lib/libcrypto.so.3)
==17==    by 0x4C2779B: RAND_bytes_ex (in /lib/libcrypto.so.3)
==17==    by 0x1885DB: janus_random_uint64_full (utils.c:85)
==17==    by 0x18863F: janus_random_uint64 (utils.c:93)
==17==    by 0x5E86D5B: janus_videoroom_process_synchronous_request (janus_videoroom.c:4751)
==17==    by 0x5E9B9B3: janus_videoroom_handle_message (janus_videoroom.c:8109)
==17==    by 0x158923: janus_process_incoming_request (janus.c:1753)
==17==    by 0x15F037: janus_transport_task (janus.c:3474)
==17== 
==17== LEAK SUMMARY:
==17==    definitely lost: 64 bytes in 2 blocks
==17==    indirectly lost: 6,736 bytes in 44 blocks
==17==      possibly lost: 0 bytes in 0 blocks
==17==    still reachable: 79,288 bytes in 727 blocks
==17==         suppressed: 0 bytes in 0 blocks
==17== Reachable blocks (those to which a pointer was found) are not shown.
==17== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==17== 
==17== For lists of detected and suppressed errors, rerun with: -s
==17== ERROR SUMMARY: 2 errors from 2 contexts (suppressed: 0 from 0)
```

Note that valgrind still complains about these blocks as being unreachable, but they are outside of the scope of tackling the actual runtime leak.