### PR TITLE
Implement file chunking for VideoRoom recordings

### DIFF
--- a/src/plugins/janus_videoroom.c
+++ b/src/plugins/janus_videoroom.c
@@ -1937,7 +1937,8 @@ static volatile gint initialized = 0, stopping = 0;
 static gboolean notify_events = TRUE;
 static gboolean string_ids = FALSE;
 static gboolean ipv6_disabled = FALSE;
-static volatile uint32_t recording_chunk_len_bytes = 5000000;
+// Default file recording chunk is 50MB
+static volatile uint32_t recording_chunk_len_bytes = 50000000;
 static janus_callbacks *gateway = NULL;
 static GThread *handler_thread;
 static void *janus_videoroom_handler(void *data);

--- a/src/postprocessing/janus-pp-rec.c
+++ b/src/postprocessing/janus-pp-rec.c
@@ -231,8 +231,6 @@ int main(int argc, char *argv[]) {
 	/* Check if we only need to print the supported extensions for all codecs */
 	if(options.fileexts_only) {
 		JANUS_LOG(LOG_INFO, "Janus version: %d (%s)\n", janus_version, janus_version_string);
-		JANUS_LOG(LOG_INFO, "Janus commit: %s\n", janus_build_git_sha);
-		JANUS_LOG(LOG_INFO, "Compiled on:  %s\n\n", janus_build_git_time);
 		JANUS_LOG(LOG_INFO, "Supported file extensions:\n");
 		char supported[100];
 		JANUS_LOG(LOG_INFO, "  -- Opus:   %s\n", janus_pp_extensions_string(janus_pp_opus_get_extensions(), supported, sizeof(supported)));
@@ -307,8 +305,6 @@ int main(int argc, char *argv[]) {
 
 	if(!jsonheader_only) {
 		JANUS_LOG(LOG_INFO, "Janus version: %d (%s)\n", janus_version, janus_version_string);
-		JANUS_LOG(LOG_INFO, "Janus commit: %s\n", janus_build_git_sha);
-		JANUS_LOG(LOG_INFO, "Compiled on:  %s\n\n", janus_build_git_time);
 		JANUS_LOG(LOG_INFO, "Logging level: %d\n", janus_log_level);
 		if(metadata)
 			JANUS_LOG(LOG_INFO, "Metadata: %s\n", metadata);

--- a/src/postprocessing/mjr2pcap.c
+++ b/src/postprocessing/mjr2pcap.c
@@ -154,8 +154,6 @@ int main(int argc, char *argv[]) {
 	atexit(janus_log_destroy);
 
 	JANUS_LOG(LOG_INFO, "Janus version: %d (%s)\n", janus_version, janus_version_string);
-	JANUS_LOG(LOG_INFO, "Janus commit: %s\n", janus_build_git_sha);
-	JANUS_LOG(LOG_INFO, "Compiled on:  %s\n\n", janus_build_git_time);
 
 	/* Evaluate arguments */
 	if(argc != 3) {

--- a/src/postprocessing/pcap2mjr.c
+++ b/src/postprocessing/pcap2mjr.c
@@ -107,8 +107,6 @@ int main(int argc, char *argv[]) {
 	atexit(janus_log_destroy);
 
 	JANUS_LOG(LOG_INFO, "Janus version: %d (%s)\n", janus_version, janus_version_string);
-	JANUS_LOG(LOG_INFO, "Janus commit: %s\n", janus_build_git_sha);
-	JANUS_LOG(LOG_INFO, "Compiled on:  %s\n\n", janus_build_git_time);
 
 	/* Parse the command-line arguments */
 	GError *error = NULL;

--- a/src/postprocessing/pp-options.c
+++ b/src/postprocessing/pp-options.c
@@ -48,8 +48,6 @@ gboolean janus_pprec_options_parse(janus_pprec_options *options, int argc, char 
 	g_option_context_add_main_entries(opts, opt_entries, NULL);
 	if(!g_option_context_parse(opts, &argc, &argv, &error)) {
 		JANUS_LOG(LOG_INFO, "Janus version: %d (%s)\n", janus_version, janus_version_string);
-		JANUS_LOG(LOG_INFO, "Janus commit: %s\n", janus_build_git_sha);
-		JANUS_LOG(LOG_INFO, "Compiled on:  %s\n\n", janus_build_git_time);
 		g_print("%s\n", error->message);
 		g_error_free(error);
 		janus_pprec_options_destroy();
@@ -62,8 +60,6 @@ gboolean janus_pprec_options_parse(janus_pprec_options *options, int argc, char 
 
 void janus_pprec_options_help(void) {
 	JANUS_LOG(LOG_INFO, "Janus version: %d (%s)\n", janus_version, janus_version_string);
-	JANUS_LOG(LOG_INFO, "Janus commit: %s\n", janus_build_git_sha);
-	JANUS_LOG(LOG_INFO, "Compiled on:  %s\n\n", janus_build_git_time);
 	char *help = g_option_context_get_help(opts, TRUE, NULL);
 	g_print("%s", help);
 	g_free(help);

--- a/src/record.h
+++ b/src/record.h
@@ -73,6 +73,8 @@ typedef struct janus_recorder {
 	janus_mutex mutex;
 	/*! \brief Atomic flag to check if this instance has been destroyed */
 	volatile gint destroyed;
+	/*! \brief Number of bytes written to the file */
+	volatile uint64_t file_len;
 	/*! \brief Reference counter for this instance */
 	janus_refcount ref;
 } janus_recorder;
@@ -139,6 +141,10 @@ int janus_recorder_opusred(janus_recorder *recorder, int red_pt);
  * @param[in] recorder The janus_recorder instance to mark as encrypted
  * @returns 0 in case of success, a negative integer otherwise */
 int janus_recorder_encrypted(janus_recorder *recorder);
+/*! \brief Peek at the current length of the recorded file, in bytes
+ * @param[in] recorder The janus_recorder instance to query
+ * @returns size of bytes in case of success, a negative integer otherwise */
+int64_t janus_recorder_peek_len(janus_recorder *recorder);
 /*! \brief Save an RTP frame in the recorder
  * @param[in] recorder The janus_recorder instance to save the frame to
  * @param[in] buffer The frame data to save


### PR DESCRIPTION
# Background
VideoRoom plugin ships with the ability to record video to the proprietary `.mjr` format out of the box, but the files are written indefinitely for the duration of the Peer Connection (or until the publisher goes into a `muted` mode, which we don't support in our usage).

# Description
This PR implements chunking recordings created by the VideoRoom plugin, with a maximum file chunk size. Of course if the stream ends prior to the chunk size, the recording is still normally created. The default max file size is 50MB, but can be configured via the `videoroom.jcfg` file in the `general` section (`recording_chunk_max_bytes = 10000000` sets to 10MB, for example).

This is fundamentally accomplished by keeping track of the `janus_recorder`'s `file_len`, and querying it via the new function `janus_recorder_peek_len()`. A new file chunk is triggered on the first keyframe after the chunk threshold is crossed.
 
# Verification
I compiled the `janus-pp-rec` utility and had it process some chunks created from my jetson's stream. I confirmed the `.mjr` files were able to be converted to `.mkv`, and the `.mkv` files were able to be played back in VLC.

I also set the max file size to be 10MB, and confirmed the `.mjr` files were cut off at the appropriate size. Note that there is inherent overhead in the `.mjr` compared to the actual video, so the `.mkv` (or whatever container its muxed into) will typically be smaller.

**Post processing**
```
janus-pp-rec videoroom-2951286120916214-user-5864365816870402-1762195434776963-video-0.mjr out/videoroom-2951286120916214-user-5864365816870402-1762195434776963-
video-0.mkv
Janus version: 1103 (1.1.3)
Logging level: 4

Source file: videoroom-2951286120916214-user-5864365816870402-1762195434776963-video-0.mjr
Target file: out/videoroom-2951286120916214-user-5864365816870402-1762195434776963-video-0.mkv

File is 7525963 bytes
Pre-parsing file to generate ordered index...
This is a video recording:
  -- Codec:   h264
  -- Created: 1762195434776968
  -- Written: 1762195434777278
SSRC detected: 3394335752
Counted 7228 RTP packets
Counted 7228 frame packets
  -- 1280x720 (fps [4500,4500] ~ 20)
[libx264 @ 0xffff8ce68880] using cpu capabilities: ARMv8 NEON
[libx264 @ 0xffff8ce68880] profile High, level 3.1, 4:2:0, 8-bit
[libx264 @ 0xffff8ce68880] 264 - core 164 - H.264/MPEG-4 AVC codec - Copyleft 2003-2022 - http://www.videolan.org/x264.html - options: cabac=1 ref=3 deblock=1:0:0 analyse=0x3:0x113 me=hex subme=7 psy=1 psy_rd=1.00:0.00 mixed_ref=1 me_range=16 chroma_me=1 trellis=1 8x8dct=1 cqm=0 deadzone=21,11 fast_pskip=1 chroma_qp_offset=-2 threads=15 lookahead_threads=2 sliced_threads=0 nr=0 decimate=1 interlaced=0 bluray_compat=0 constrained_intra=0 bframes=3 b_pyramid=2 b_adapt=1 b_bias=0 direct=1 weightb=1 open_gop=0 weightp=2 keyint=250 keyint_min=20 scenecut=40 intra_refresh=0 rc_lookahead=40 rc=crf mbtree=1 crf=23.0 qcomp=0.60 qpmin=0 qpmax=69 qpstep=4 ip_ratio=1.40 aq=1:1.00
First keyframe: 0
out/videoroom-2951286120916214-user-5864365816870402-1762195434776963-video-0.mkv is 7312745 bytes
Bye!
```

**File system with mjr & converted mkvs**
<img width="1072" height="220" alt="Screenshot 2025-11-03 at 10 56 01 AM" src="https://github.com/user-attachments/assets/491463c0-4791-4280-9232-e406ca1ed0b1" />

**Screenshots from the two recorded videos**
<img width="1283" height="782" alt="Screenshot 2025-11-03 at 10 54 20 AM" src="https://github.com/user-attachments/assets/399a9482-77db-403d-af31-21fbc912c3c7" />
<img width="1280" height="781" alt="Screenshot 2025-11-03 at 10 54 11 AM" src="https://github.com/user-attachments/assets/791ec4b2-7ee4-432c-aa3d-4c2579cd7da8" />



